### PR TITLE
Add anti-hotlinking support and a MySQL framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,15 +27,18 @@ Requirements
 ------------
 
 Directory Lister requires PHP 5.3+ to work properly.  For more information on PHP, please visit
-<http://www.php.net>.
+<http://www.php.net>. Php also requires mysql support. You need a mysql server installed and running.
 
 
 Installation
 ------------
 
+<<<<<<< HEAD
   1. Copy `resources/default.config.php` to `resources/config.php`
-  2. Upload `index.php` and the `resources` folder to the folder you want listed
-  3. Upload additional files to the same directory as index.php
+  2. Setup information in dbconnect.php for your MySQL settings
+  3. Upload the root of this folder to document root of your site
+  4. Run the install.php, then delete it.
+  5. Upload additional files to the same directory as index.php
 
 
 Troubleshooting

--- a/dbconnect.php
+++ b/dbconnect.php
@@ -1,0 +1,13 @@
+<?php
+//Your mysql host goes here (localhost unless your using a remote server)
+$host = 'localhost';
+//Your mysql username and password
+$user = 'root';
+$password = 'Password';
+//The name of the database you are going to use
+$dbname = 'FileDownloads';
+
+// Connect to database  using: dbname , username , password
+	$link = mysql_connect($host, $user, $password) or die("Could not connect: " . mysql_error());
+	mysql_select_db($dbname) or die(mysql_error());
+?>

--- a/download.php
+++ b/download.php
@@ -1,0 +1,131 @@
+<?php
+require ('dbconnect.php');
+
+$maxdownloads = "2";
+$maxtime = "7200";
+
+function readfile_chunked ($fname) {
+	$chunksize = 1*(1024*1024);
+	$buffer = '';
+	$handle = fopen($fname, 'rb');
+	if ($handle === false) {
+		return false;
+	}
+	while (!feof($handle)) {
+		$buffer = fread($handle, $chunksize);
+		print $buffer;
+	}
+	return fclose($handle);
+}
+
+if(get_magic_quotes_gpc()) {
+	$id = stripslashes($_GET['id']);
+}else{
+	$id = $_GET['id'];
+}
+
+//  the filename, key, timestamp, and number of downloads from the database
+
+$query = sprintf("SELECT * FROM downloadkey WHERE uniqueid= '%s'",
+mysql_real_escape_string($id, $link));
+$result = mysql_query($query) or die(mysql_error());
+$row = mysql_fetch_array($result);
+
+if (!$row) {
+	echo "The download key you are using is invalid.";
+}else{
+	$fname = $row['filename'];
+	$timecheck = date('U') - $row['timestamp'];
+		if ($timecheck >= $maxtime) {
+			echo "This key has expired (exceeded time allotted).<br/>";
+		}else{
+			$downloads = $row['downloads'];
+			$downloads += 1;
+			if ($downloads > $maxdownloads) {
+			echo "This key has expired (exceeded allowed downloads).<br />";
+				}else{
+					$sql = sprintf("UPDATE downloadkey SET downloads = '".$downloads."' WHERE uniqueid= 
+'%s'",
+					mysql_real_escape_string($id, $link));
+					$incrementdownloads = mysql_query($sql) or die(mysql_error());
+					$path = getcwd();
+					//Check for various invalid files, and loop holes like ../ and ./
+						if($fname == '.' || $fname == './' || $fname == "download.php" || $fname == 
+"index.php" || !file_exists($fname) || empty($fname) || preg_match('/\..\|\.\|\.|resources/',$fname))
+						{
+							echo "Invalid File or File Not Specified";
+							exit(0);
+				}
+
+			// Declare arrays for filename and count
+			$name = array();
+			$count = array();
+			// Create log file if it does not exist
+			touch("$path/resources/log");
+			// Open log file in read mode
+			$file = fopen("$path/resources/log","r");
+			// Read the entire contents of the file into the arrays
+			while ($data = fscanf($file,"%[ -~]\t%d\n"))
+			{
+				list ($temp1, $temp2) = $data;
+				array_push($name,$temp1);
+				array_push($count,$temp2);
+			}
+			fclose($file);
+			// If the file entry exists in the log, increment its count
+			if(in_array($fname,$name))
+			{
+				$key=array_search($fname,$name);
+				$count[$key]+=1;
+			}
+			// Otherwise, create a new array entry for the file
+			else
+			{
+				array_push($name,$fname);
+				array_push($count,1);
+			}
+
+			// Combine the two arrays into new array with filename as key, and count as value
+			$list=array_combine($name,$count);
+			ksort($list);
+			// Open the file in write mode to clear all its contents
+			$file=fopen("$path/resources/log","w");
+
+			// For each key and value in the list, print to file
+			while (list($key, $val) = each($list))
+			{
+				fprintf($file,"%s\t%d\n",$key,$val);
+			}
+			fclose($file);
+
+			// Initiate force file download
+			// fix for IE catching or PHP bug issue
+			@header("Pragma: public");
+			@header("Expires: 0"); // set expiration time
+			@header("Cache-Control: must-revalidate, post-check=0, pre-check=0");
+			// browser must download file from server instead of cache
+			// force download dialog
+			@header("Content-Type: application/force-download");
+			@header("Content-Type: application/octet-stream");
+			@header("Content-Type: application/download");
+
+			// use the Content-Disposition header to supply a recommended filename and
+			// force the browser to display the save dialog.
+
+			@header("Content-Disposition: attachment; filename=\"".basename($fname)."\"" );
+
+			/*
+			The Content-transfer-encoding header should be binary, since the file will be read
+			directly from the disk and the raw bytes passed to the downloading computer.
+			The Content-length header is useful to set for downloads. The browser will be able to
+			show a progress meter as a file downloads. The content-lenght can be determines by
+			Filesize function returns the size of a file.
+			*/
+			@header("Content-Transfer-Encoding: binary");
+			@header("Content-Length: ".filesize($fname));
+			@readfile_chunked($fname);
+			exit(0);
+		}
+	}
+}
+?>

--- a/getdownload.php
+++ b/getdownload.php
@@ -1,0 +1,94 @@
+<?php
+// A script to generate unique download keys for the purpose of protecting downloadable goods
+
+require ('dbconnect.php');
+
+	// Get the filename given by directory linker
+	$fileget = $_GET["file"];
+	
+	// Prevent downloading outside of directory listing bounds
+	if (substr($fileget, 0, 1) == '/') {
+		$file = substr($fileget, 1);
+	} else {
+		$file = $fileget;
+	}
+
+	if(empty($_SERVER['REQUEST_URI'])) {
+    	$_SERVER['REQUEST_URI'] = $_SERVER['SCRIPT_NAME'];
+	}
+
+	// Strip off query string so dirname() doesn't get confused
+	$url = preg_replace('/\?.*$/', '', $_SERVER['REQUEST_URI']);
+	$folderpath = 'http://'.$_SERVER['HTTP_HOST'].'/'.ltrim(dirname($url), '/');
+
+	// Add some salt
+        $s1 = md5('GetFilesToday134364529193sad5He%#ll##@@!oSa#ltmy12!@$@');
+        $s2 = rand();
+        $s3 = $s1.md5($s2.rand().$s1).$s1;
+	// Generate the unique download key
+	$key = $s1.$s3.uniqid(md5(rand())).$s2;
+
+	// Get the activation time
+	$time = date('U');
+
+// Write the key and activation time to the database as a new row.
+	$registerid = mysql_query("INSERT INTO downloadkey (uniqueid,timestamp,filename) 
+                                   VALUES(\"$key\",\"$time\",\"$file\")") or die(mysql_error());
+
+// Create the filename
+function curPageURL() {
+ $pageURL = 'http';
+ if ($_SERVER["HTTPS"] == "on") {$pageURL .= "s";}
+ $pageURL .= "://";
+ if ($_SERVER["SERVER_PORT"] != "80") {
+  $pageURL .= $_SERVER["SERVER_NAME"].":".$_SERVER["SERVER_PORT"].$_SERVER["REQUEST_URI"];
+ } else {
+  $pageURL .= $_SERVER["SERVER_NAME"].$_SERVER["REQUEST_URI"];
+ }
+ return $pageURL;
+}
+
+?>
+
+<DOCUTYPE html>
+<head>
+<title> Sick Files </title>
+<script type="text/javascript">
+                    window.setTimeout(function() {
+                        location.href = 'index.php';
+                    }, 10000);
+</script>
+</head>
+<body>
+<p>
+<center>
+<?php
+$filename = basename($file);
+$filemd5 = $file . ".md5";
+$ext = pathinfo($filename, PATHINFO_EXTENSION);
+echo "<a href=\"$data\">$filename</a>";
+echo "<br><br>";
+$query = sprintf("SELECT * FROM md5sums WHERE filename= '%s'",
+mysql_real_escape_string($file));
+$result = mysql_query($query) or die(mysql_error());
+$row = mysql_fetch_array($result);
+        if (!$row) {
+                $md5 = md5_file($file);
+                $sqlread = mysql_query("INSERT INTO md5sums (filename,md5) VALUES(\"$file\",\"$md5\")") or die(mysql_error());
+                echo "MD5: " . $md5;
+        }else{
+                echo "MD5: " . $row['md5'];
+}
+echo "<br><br>";
+echo "Redirecting in 10 seconds"; ?> </p>
+
+<p>Click here if you are not redirected automatically in 10 seconds<br/>
+            <a href="index.php">Get More Files</a>.
+</p>
+<?php
+// Redirect to the download
+echo '<META HTTP-EQUIV="Refresh" Content="2; URL=download.php?id=' . $key . '">';
+//show HTML below for 5 seconds
+?>
+</body>
+</html>

--- a/install.php
+++ b/install.php
@@ -1,0 +1,49 @@
+<?php
+//YOU MUST SET THE VARIABLES BELOW OR IT WONT WORK
+$hostname = 'localhost';
+$username = 'root';
+$password = 'Password';
+
+$con = mysql_connect($hostname,$username,$password);
+if (!$con)
+  {
+  die('Could not connect: ' . mysql_error());
+  }
+
+if (mysql_query("CREATE DATABASE FileDownloads",$con))
+  {
+  echo "Database created";
+  }
+else
+  {
+  echo "Error creating database: " . mysql_error();
+  }
+
+mysql_select_db("FileDownloads", $con);
+
+$dltbl = "CREATE TABLE downloadkey
+(
+uniqueid varchar(255) NOT NULL default '',
+timestamp varchar(255) NOT NULL default '',
+filename varchar(255) NOT NULL default '',
+downloads varchar(255) NOT NULL default '0'
+)";
+mysql_query($dltbl,$con);
+
+$md5tbl = "CREATE TABLE md5sums
+(
+filename varchar(255) NOT NULL default '',
+md5 varchar(255) NOT NULL default ''
+)";
+mysql_query($md5tbl,$con);
+
+$reftbl = "CREATE TABLE referer
+(
+referer varchar(255) NOT NULL default '',
+count varchar(255) NOT NULL default '',
+)";
+mysql_query($reftbl,$con);
+
+mysql_close($con);
+echo "WARNING YOU MUST REMOVE THIS FILE OR SUFFER THE CONSEQUINCES!!!"
+?>

--- a/resources/default.config.php
+++ b/resources/default.config.php
@@ -13,7 +13,11 @@ return array(
         '.htaccess',
         '.htpasswd',
         'resources',
-        'analytics.inc'
+        'analytics.inc',
+	'dbconnect.php',
+	'download.php',
+	'getdownload.php',
+	'install.php'
     ),
 
     // Custom sort order

--- a/resources/themes/bootstrap/index.php
+++ b/resources/themes/bootstrap/index.php
@@ -74,7 +74,7 @@
 
                 <?php foreach($dirArray as $name => $fileInfo): ?>
                     <li class="clearfix" data-name="<?php echo $name; ?>" data-href="<?php echo $fileInfo['file_path']; ?>">
-                        <a href="<?php echo $fileInfo['file_path']; ?>" class="clearfix" data-name="<?php echo $name; ?>">
+                        <a href="<?php echo "getdownload.php?file=".$fileInfo['file_path']; ?>" class="clearfix" data-name="<?php echo $name; ?>">
 
                             <span class="file-name">
                                 <span class="icon-wrapper">


### PR DESCRIPTION
This system allows for hotlink prevention and useage of ads (with a direct link) To prevent hotlinking, disable indexing of your directories and then block all attempts to access any file thats not in resources/ or that is not index.php getdownload.php or download.php. With these changes, the md5 is also shown at download time and a ten second counter starts for the download. This also adds a MySQL backing and framework that allows for the addition of download counts and file information storage so that the server doe not generate file information every time that the php is generated.
