### PR TITLE
UTF-8 support

### DIFF
--- a/resources/themes/bootstrap/index.php
+++ b/resources/themes/bootstrap/index.php
@@ -4,6 +4,7 @@
 
     <head>
 
+        <meta charset='utf-8'>
         <title>Directory listing of <?php echo $lister->getListedPath(); ?></title>
         <link rel="shortcut icon" href="<?php echo THEMEPATH; ?>/img/folder.png">
 


### PR DESCRIPTION
Without those (ugly?) fix some nonsense shown instead of cyrillic files\folders names. Tested with Firefox 21,22,23.

Sorry, I'm not a web developer, so I can't offer more gracefull solution, but I think DirectoryLister must support UTF-8 "out of the box".

Regards, Alexander Ryzhov.
