### PR TITLE
Fixes for issue #37 and #24 in main repo

### DIFF
--- a/resources/default.config.php
+++ b/resources/default.config.php
@@ -7,6 +7,7 @@ return array(
     'list_folders_first' => true,
     'list_sort_order'    => 'natcasesort',
     'theme_name'         => 'bootstrap',
+    'hash_size_limit'    => 200000000, //200 MB(ish)
 
     // Hidden files
     'hidden_files' => array(

--- a/resources/themes/bootstrap/index.php
+++ b/resources/themes/bootstrap/index.php
@@ -139,6 +139,11 @@
                                     <td class="sha1-hash">{{sha1_sum}}</td>
                                 </tr>
 
+                                <tr>
+                                    <td class="table-title">Size</td>
+                                    <td class="filesize">{{file_size}}</td>
+                                </tr>
+
                             </tbody>
                         </table>
 

--- a/resources/themes/bootstrap/js/directorylister.js
+++ b/resources/themes/bootstrap/js/directorylister.js
@@ -24,6 +24,13 @@ $(document).ready(function() {
         var name = $(this).closest('li').attr('data-name');
         var path = $(this).closest('li').attr('data-href');
 
+        // Set modal title value
+        $('#file-info-modal .modal-title').text(name);
+
+        $('#file-info .md5-hash').text('Loading...');
+        $('#file-info .sha1-hash').text('Loading...');
+        $('#file-info .filesize').text('Loading...');
+
         $.ajax({
             url:     '?hash=' + path,
             type:    'get',
@@ -32,12 +39,11 @@ $(document).ready(function() {
                 // Parse the JSON data
                 var obj = jQuery.parseJSON(data);
 
-                // Set modal title value
-                $('#file-info-modal .modal-title').text(name);
 
                 // Set modal pop-up hash values
                 $('#file-info .md5-hash').text(obj.md5);
                 $('#file-info .sha1-hash').text(obj.sha1);
+                $('#file-info .filesize').text(obj.size);
 
             }
         });


### PR DESCRIPTION
Fix for issue #37 in main repo (show filesize in MB, instead of KB). Now should show relevant size up to Petabytes.

Fix for issue #24 in main repo (Checksum generation takes a while on large files):
  Added option to limit checksum generation for files above an arbitrary size.
  Added js code to set loading texts while waiting for the ajax request to finish. Incidently, the hashing will continue regardless if the request is cancelled or not.
  Added file size to the info page, in case it gets cut off in the listing
