### PR TITLE
Fix direct file links

### DIFF
--- a/resources/DirectoryLister.php
+++ b/resources/DirectoryLister.php
@@ -470,7 +470,7 @@ class DirectoryLister {
                     // Add all non-hidden files to the array
                     if ($this->_directory != '.' || $file != 'index.php') {
 
-                        $urlPath = rawurlencode($relativePath);
+                        $urlPath = implode('/', array_map(rawurlencode, explode("/", $relativePath)));
 
                         // Build the file path
                         if (is_dir($relativePath)) {


### PR DESCRIPTION
This only urlencodes the file components, not the directory separators. We had needed this to properly browse.
