### PR TITLE
Add feature to link to, rather than browse, directories with their own i...

### DIFF
--- a/resources/DirectoryLister.php
+++ b/resources/DirectoryLister.php
@@ -428,6 +428,9 @@ class DirectoryLister {
                 if (is_dir($realPath)) {
                     $iconClass = 'fa-folder';
                     $sort = 1;
+                    if (!$this->_isBrowseDir($realPath)) {
+                        $iconClass = 'fa-bookmark';
+                    }
                 } else {
                     // Get file extension
                     $fileExt = strtolower(pathinfo($realPath, PATHINFO_EXTENSION));
@@ -471,7 +474,7 @@ class DirectoryLister {
                     if ($this->_directory != '.' || $file != 'index.php') {
 
                         // Build the file path
-                        if (is_dir($relativePath)) {
+                        if (is_dir($relativePath) && $this->_isBrowseDir($relativePath)) {
                             $urlPath = '?dir=' . rawurlencode($relativePath);
                         } else {
                             $urlPath = rawurlencode($relativePath);
@@ -632,6 +635,29 @@ class DirectoryLister {
         }
 
         return false;
+
+    }
+
+    /**
+     * Determines if a file is specified as a browsed subdirectory (no index)
+     *
+     * @param string $dirPath Path to directory to be checked for an index
+     * @return boolean Returns false if directory has a valid index file, true if not
+     * @access protected
+     */
+    protected function _isBrowseDir($dirPath) {
+        // Check directory for each index file name.
+        foreach ($this->_config['index_files'] as $indexFile) {
+
+            if (file_exists(implode('/', array($dirPath, $indexFile)))) {
+
+                return false;
+
+            }
+
+        }
+
+        return true;
 
     }
 

--- a/resources/default.config.php
+++ b/resources/default.config.php
@@ -16,6 +16,14 @@ return array(
         'analytics.inc'
     ),
 
+    // Files that, if present in a directory, make the directory a direct link
+    // rather than a browse link.
+    'index_files' => array(
+        'index.htm',
+        'index.html',
+        'index.php'
+    ),
+
     // File hashing threshold
     'hash_size_limit' => 268435456, // 256 MB
 


### PR DESCRIPTION
This adds a useful new feature.  The user can specify in their config some filenames (defaults provided, like `index.htm`, `index.php`, etc) that, if detected in a directory, will result in that directory not being browsed but rather linked directly.

The use case that prompted this was having DirectoryLister drive a quick developer portal: we had directories with binaries, etc. to download, but also uploaded Doxygen-generated documentation in the same place and didn't want to have a manually-updated homepage.
