### PR TITLE
Fix filesize units #2

### DIFF
--- a/resources/DirectoryLister.php
+++ b/resources/DirectoryLister.php
@@ -356,7 +356,7 @@ class DirectoryLister {
         $factor = floor((strlen($bytes) - 1) / 3);
 
         // Calculate the file size
-        $fileSize = sprintf('%.2f', $bytes / pow(1024, $factor)) . $sizes[$factor];
+        $fileSize = sprintf('%.2f', $bytes / pow(1000, $factor)) . $sizes[$factor];
 
         return $fileSize;
 


### PR DESCRIPTION
Use power of 1000 when calculating SI units.