### PR TITLE
added readme/header function

### DIFF
--- a/resources/default.config.php
+++ b/resources/default.config.php
@@ -50,4 +50,15 @@ return array(
         // 'path/to/folder'
     ),
 
+    // Disable Readme function
+    'show_readme' => true,
+
+    //Disable readme show in specified directories
+    'hidden_readme_files' => array(),
+
+    //Which filename should be used?
+    'readme_files' => array( 'README', "README.html" ),
+
+    //Should the shown files be removed from list?
+    'remove_showed_readme' => true
 );

--- a/resources/themes/bootstrap/default_footer.php
+++ b/resources/themes/bootstrap/default_footer.php
@@ -1,5 +1,5 @@
 <hr>
 
 <div class="footer">
-    Powered by, <a href="http://www.directorylister.com">Directory Lister</a>
+    Powered by <a href="http://www.directorylister.com">Directory Lister</a>
 </div>

--- a/resources/themes/bootstrap/index.php
+++ b/resources/themes/bootstrap/index.php
@@ -70,7 +70,23 @@
 
             </div>
         </div>
-
+        <?php
+        $a = $lister->getReadmeContent( $lister->getDirectoryPath() );
+        if ( ! empty( $a['html'] ) ) :
+	        $dirArray = $a["dirArray"];
+	        ?>
+        <div id="readme-content" class="container">
+	        <div class="row">
+		        <div class="col-md-12 text-center">
+			        <?php
+			            echo $a["html"];
+			        ?>
+		        </div>
+	        </div>
+        </div>
+        <?php
+        endif;
+        ?>
         <div id="page-content" class="container">
 
             <?php file_exists('header.php') ? include('header.php') : include($lister->getThemePath(true) . "/default_header.php"); ?>


### PR DESCRIPTION
Hey!

This request adds a simple way of showing file content between navigation and content.
![modification-readme](https://cloud.githubusercontent.com/assets/8635754/12329522/051ada00-bae1-11e5-8f7f-1fdea95a54f6.png)

When using [Apache  a ```HEADER.html```](https://httpd.apache.org/docs/2.4/mod/mod_autoindex.html#headername) can be used to show content above file list. This modification adds something like that to DirectoryLister.
