### PR TITLE
Added functionality to use real urls for indexed directories

### DIFF
--- a/resources/DirectoryLister.php
+++ b/resources/DirectoryLister.php
@@ -297,7 +297,19 @@ class DirectoryLister {
     public function externalLinksNewWindow() {
         return $this->_config['external_links_new_window'];
     }
-
+    
+    
+    /**
+     * Returns use real url for indexed directories
+     *
+     * @return boolean Returns true if in config is enabled links for directories with index, false if not
+     * @access public
+     */
+    public function linksForDirsWithIndex()
+    {
+        return $this->_config['links_for_dirs_with_index'];
+    }
+    
 
     /**
      * Returns the path to the chosen theme directory
@@ -618,6 +630,12 @@ class DirectoryLister {
                             $urlPath = '?dir=' . $urlPath;
                         } else {
                             $urlPath = $urlPath;
+                        }
+                        
+                        if ($this->linksForDirsWithIndex()) {
+                            if ($this->containsIndex($relativePath)) {
+                                $urlPath = $relativePath;
+                            }
                         }
 
                         // Add the info to the main array

--- a/resources/default.config.php
+++ b/resources/default.config.php
@@ -8,6 +8,7 @@ return array(
     'list_sort_order'           => 'natcasesort',
     'theme_name'                => 'bootstrap',
     'external_links_new_window' => true,
+    'links_for_dirs_with_index' => false,
 
     // Hidden files
     'hidden_files' => array(

--- a/resources/themes/bootstrap/index.php
+++ b/resources/themes/bootstrap/index.php
@@ -124,11 +124,15 @@
 
                         <?php else: ?>
 
-                            <?php if ($lister->containsIndex($fileInfo['file_path'])): ?>
+                            <?php if (!$lister->linksForDirsWithIndex()): ?>
 
-                                <a href="<?php echo $fileInfo['file_path']; ?>" class="web-link-button" <?php if($lister->externalLinksNewWindow()): ?>target="_blank"<?php endif; ?>>
-                                    <i class="fa fa-external-link"></i>
-                                </a>
+                                <?php if ($lister->containsIndex($fileInfo['file_path'])): ?>
+
+                                    <a href="<?php echo $fileInfo['file_path']; ?>" class="web-link-button" <?php if($lister->externalLinksNewWindow()): ?>target="_blank"<?php endif; ?>>
+                                        <i class="fa fa-external-link"></i>
+                                    </a>
+
+                                <?php endif; ?>
 
                             <?php endif; ?>
 


### PR DESCRIPTION
I personally use directorylister to give a nice look for my packages at [my website](http://packages.ozankurt.com). I don't want people to see the files that APIgen generated for my package. Instead I want to link them directly to the folder itself and let them view the API for my package.
