### PR TITLE
Added Ability to Set Main Index File

### DIFF
--- a/resources/DirectoryLister.php
+++ b/resources/DirectoryLister.php
@@ -193,7 +193,7 @@ class DirectoryLister {
 
         // Statically set the Home breadcrumb
         $breadcrumbsArray[] = array(
-            'link' => $this->_appURL,
+            'link' => $this->_appURL . $this->_config['main_index_file'],
             'text' => 'Home'
         );
 
@@ -215,7 +215,7 @@ class DirectoryLister {
                 }
 
                 // Combine the base path and dir path
-                $link = $this->_appURL . '?dir=' . rawurlencode($dirPath);
+                $link = $this->_appURL . $this->_config['main_index_file'] . '?dir=' . rawurlencode($dirPath);
 
                 $breadcrumbsArray[] = array(
                     'link' => $link,
@@ -598,7 +598,7 @@ class DirectoryLister {
                         // Add file info to the array
                         $directoryArray['..'] = array(
                             'file_path'  => $this->_appURL . $directoryPath,
-                            'url_path'   => $this->_appURL . $directoryPath,
+                            'url_path'   => $this->_appURL . $this->_config['main_index_file'] . $directoryPath,
                             'file_size'  => '-',
                             'mod_time'   => date('Y-m-d H:i:s', filemtime($realPath)),
                             'icon_class' => 'fa-level-up',
@@ -815,7 +815,7 @@ class DirectoryLister {
         }
 
         // Build the application URL
-        $appUrl = $protocol . $host . $path;
+        $appUrl = $protocol . $host . $path . $this->_config['main_index_file'];
 
         // Return the URL
         return $appUrl;

--- a/resources/default.config.php
+++ b/resources/default.config.php
@@ -8,7 +8,7 @@ return array(
     'list_sort_order'           => 'natcasesort',
     'theme_name'                => 'bootstrap',
     'external_links_new_window' => true,
-    'main_index_file'			=> 'cdn.php',
+    'main_index_file'           => 'index.php',
 
     // Hidden files
     'hidden_files' => array(

--- a/resources/default.config.php
+++ b/resources/default.config.php
@@ -8,6 +8,7 @@ return array(
     'list_sort_order'           => 'natcasesort',
     'theme_name'                => 'bootstrap',
     'external_links_new_window' => true,
+    'main_index_file'			=> 'cdn.php',
 
     // Hidden files
     'hidden_files' => array(


### PR DESCRIPTION
You can now use DirectoryLister via a file other than index.php.  Simply copy the contents of index.php to another php file and set 'main_index_file' in config.php to reflect this change.
