### PR TITLE
Fix error on `array_reverse` of null array

### DIFF
--- a/resources/DirectoryLister.php
+++ b/resources/DirectoryLister.php
@@ -709,8 +709,8 @@ class DirectoryLister {
             }
 
             if ($reverse) {
-                $sortedArray[1] = array_reverse($sortedArray[1]);
-                $sortedArray[2] = array_reverse($sortedArray[2]);
+                if (!empty($sortedArray[1])) $sortedArray[1] = array_reverse($sortedArray[1]);
+                if (!empty($sortedArray[2])) $sortedArray[2] = array_reverse($sortedArray[2]);
             }
 
         } else {
@@ -728,7 +728,7 @@ class DirectoryLister {
             }
 
             if ($reverse) {
-                $sortedArray[1] = array_reverse($sortedArray[1]);
+                if (!empty($sortedArray[1])) $sortedArray[1] = array_reverse($sortedArray[1]);
             }
 
         }


### PR DESCRIPTION
This can occur if a directory is filtered out. In my case, all folders were filtered out, resulting in this issue