### PR TITLE
Added native support for GA with download event tracking.

### DIFF
--- a/resources/DirectoryLister.php
+++ b/resources/DirectoryLister.php
@@ -286,6 +286,27 @@ class DirectoryLister {
         return $this->_config['theme_name'];
     }
 
+    /**
+     * Returns true if GA is enabled
+     *
+     * @return boolean
+     * @access public
+     */
+    public function isGoogleAnalyticsEnabled()
+    {
+        return $this->_config['ga_enabled'];
+    }
+
+    /**
+     * Returns the code of the GA instance
+     *
+     * @return string
+     * @access public
+     */
+    public function getGoogleAnalyticsCode()
+    {
+        return $this->_config['ga_code'];
+    }
 
     /**
      * Returns open links in another window

--- a/resources/default.config.php
+++ b/resources/default.config.php
@@ -58,4 +58,8 @@ return array(
         // 'path/to/folder'
     ),
 
+    // Google Analytics Tracking
+    'ga_enabled' => true,
+    'ga_code' => 'UA-XXXXXXX-XX',
+
 );

--- a/resources/themes/bootstrap/index.php
+++ b/resources/themes/bootstrap/index.php
@@ -4,6 +4,19 @@
 
     <head>
 
+        <?php if($lister->isGoogleAnalyticsEnabled()): ?>
+        <!-- Global site tag (gtag.js) - Google Analytics -->
+        <script async src="https://www.googletagmanager.com/gtag/js?id=<?php echo $lister->getGoogleAnalyticsCode(); ?>"></script>
+        <script>
+          window.dataLayer = window.dataLayer || [];
+          function gtag(){dataLayer.push(arguments);}
+          gtag('js', new Date());
+
+          gtag('config', '<?php echo $lister->getGoogleAnalyticsCode(); ?>');
+        </script>
+        <?php endif; ?>
+
+
         <title>Directory listing of <?php echo $lister->getListedPath(); ?></title>
         <link rel="shortcut icon" href="<?php echo THEMEPATH; ?>/img/folder.png">
 

--- a/resources/themes/bootstrap/js/directorylister.js
+++ b/resources/themes/bootstrap/js/directorylister.js
@@ -55,6 +55,18 @@ $(document).ready(function() {
 
     });
 
+    if(gtag !== undefined) {
+        $('#directory-listing li > a').click(function() {
+            if ($(this).attr('href').substring(0, 4) == "?dir" || $(this).data('name').substring(0, 2) == "..") {
+                return;
+            }
+            gtag('event', 'download', {
+              event_category: 'Files',
+              event_label: $(this).data('name')
+            });
+        });
+    }
+
 });
 
 function showHideTopLink(elTop) {


### PR DESCRIPTION
Needed this for vyos.io so we decided to share it with the community.

You add your GA ID in the config and it will enable the GA tag and track the download events.