### PR TITLE
Use protocol forwarded from reverse proxy

### DIFF
--- a/resources/DirectoryLister.php
+++ b/resources/DirectoryLister.php
@@ -800,7 +800,9 @@ class DirectoryLister {
     protected function _getAppUrl() {
 
         // Get the server protocol
-        if (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') {
+        if (isset($_SERVER['HTTP_X_FORWARDED_PROTO'])) {
+            $protocol = $_SERVER['HTTP_X_FORWARDED_PROTO'] . '://';
+        } else if (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') {
             $protocol = 'https://';
         } else {
             $protocol = 'http://';


### PR DESCRIPTION
Reverse proxies are commonly configured to provide X-Forwarded-For and X-Forwarded-Proto to identify the front end/ingress point to the backend web server. Currently, DirectoryLister interprets X-Forwarded-For. This trivial change adds recognition for X-Forwarded-Proto.

This resolves the problem with the Home link noted by @insink71 in #25, specifically in the case where a proxy is used to do SSL termination in front of a non-SSL server.