### PR TITLE
Allow custom sort functions

### DIFF
--- a/resources/DirectoryLister.php
+++ b/resources/DirectoryLister.php
@@ -694,6 +694,9 @@ class DirectoryLister {
             case 'shuffle':
                 shuffle($keys);
                 break;
+            case 'custom':
+                $keys = $this->_config['list_sort_order_function']($array);
+                break;
         }
 
         // Loop through the sorted values and move over the data


### PR DESCRIPTION
This very small addition allows adding custom sort functions by setting `list_sort_order` to `custom` and providing a callable function to `list_sort_order_function` which takes an array of files and returns its sorted keys (file- and dirnames). Sorting by last modification could look like this:

```php
<?php
// config.php

function modsort($array) {
    uasort($array, function($a, $b) {
        return strtotime($a['mod_time']) > strtotime($b['mod_time']);
    });
    return array_keys($array);
}

return array(
    // ...
    'list_sort_order'          => 'custom',
    'list_sort_order_function' => 'modsort',
    // ...
);
```