### PR TITLE
Bring back the button to open directory with index

### DIFF
--- a/resources/DirectoryLister.php
+++ b/resources/DirectoryLister.php
@@ -16,7 +16,7 @@
 class DirectoryLister {
 
     // Define application version
-    const VERSION = '2.7.1';
+    const VERSION = '2.7.2';
 
     // Reserve some variables
     protected $_themeName     = null;
@@ -233,22 +233,16 @@ class DirectoryLister {
      */
     public function containsIndex($dirPath) {
 
-        // Check if links_dirs_with_index is enabled
-        if ($this->linksDirsWithIndex()) {
+        // Check if directory contains an index file
+        foreach ($this->_config['index_files'] as $indexFile) {
 
-            // Check if directory contains an index file
-            foreach ($this->_config['index_files'] as $indexFile) {
+            if (file_exists($dirPath . '/' . $indexFile)) {
 
-                if (file_exists($dirPath . '/' . $indexFile)) {
-
-                    return true;
-
-                }
+                return true;
 
             }
 
         }
-
 
         return false;
 

--- a/resources/themes/bootstrap/index.php
+++ b/resources/themes/bootstrap/index.php
@@ -122,6 +122,20 @@
                                 <i class="fa fa-info-circle"></i>
                             </a>
 
+                        <?php else: ?>
+
+                            <?php if (!$lister->linksDirsWithIndex()): ?>
+
+                                    <?php if ($lister->containsIndex($fileInfo['file_path'])): ?>
+
+                                        <a href="<?php echo $fileInfo['file_path']; ?>" class="web-link-button"<?php if ($lister->externalLinksNewWindow()): ?> target="_blank"<?php endif; ?>>
+                                            <i class="fa fa-external-link"></i>
+                                        </a>
+
+                                    <?php endif; ?>
+
+                            <?php endif; ?>
+
                         <?php endif; ?>
 
                     </li>


### PR DESCRIPTION
It was lost between PR #116 and 22661b627244ff608d095563766641af5f864087

I, personally, used this button ALL the time. It was a helpful shortcut if you knew you only wanted to start at the index but still gave you the ability to see the directory if you didn't (unlike with the new `links_dirs_with_index` config option).