### PR TITLE
Search input: Placeholder color to white, outline width removed

### DIFF
--- a/app/views/components/search.twig
+++ b/app/views/components/search.twig
@@ -1,6 +1,7 @@
 <form id="search" action="." method="get" class="group relative block bg-blue-700 rounded-full shadow-inner">
     <input type="text" value="{{ search }}" name="search" placeholder="{{ translate('search') }}..."
-        class="bg-transparent placeholder-gray-900 text-white w-full px-10 py-2"
+        class="bg-transparent text-white w-full px-10 py-2"
+        style="outline-width:inherit;"
         ref="searchInput" v-on:focus="$event.target.select()"
     >
 


### PR DESCRIPTION
Updated search input to have white placeholder text instead of `placeholder-gray-900`. Input had outline on focus, this is also removed in [this commit](https://github.com/DirectoryLister/DirectoryLister/commit/ccd00bb4ea21ef1a2ef5b9496b87c13446880e6b).