### PR TITLE
Block listing and vendor files with Apache config

### DIFF
--- a/app/.htaccess
+++ b/app/.htaccess
@@ -1,0 +1,1 @@
+Options -Indexes

--- a/app/vendor/.htaccess
+++ b/app/vendor/.htaccess
@@ -1,0 +1,1 @@
+Require all denied


### PR DESCRIPTION
Block /app/vendor and prevent listing of /app. Only works on Apache.