### PR TITLE
Correct translation of es.yaml

### DIFF
--- a/app/translations/es.yaml
+++ b/app/translations/es.yaml
@@ -1,4 +1,4 @@
-home: Hogar
+home: Inicio
 download: Descargar este Directorio
 search: Buscar
 file:
@@ -7,8 +7,8 @@ file:
   date: Fecha
   info: Información del Archivo
 powered_by: Desarrollado por
-scroll_to_top: Vuelve al Comienzo
-toggle_theme: Alternar modo claro/oscuro
+scroll_to_top: Desplazarse hacia arriba
+toggle_theme: Cambiar modo claro/oscuro
 
 error:
   directory_not_found: El directorio no existe
@@ -17,4 +17,4 @@ error:
   no_results_found: No se han encontrado resultados
   unexpected: Ocurrió un error inesperado
 
-enable_debugging: Habilite la "debugging" para obtener información adicional
+enable_debugging: Habilite la depuración para obtener información adicional


### PR DESCRIPTION
1. The correct translation is "Inicio", it indicates the beginning of the page. Which in this case, is the main directory

2. Changed from "Volver al inicio" to "Desplazarse hacia arriba", making it more understandable

3. The word "Alternar" is corrected to "Cambiar", which is mostly used in Spanish

4. The sentence is completely translated

Mr. programmer, your project is great. Greetings ^_^