### PR TITLE
Provide lang for html tag

### DIFF
--- a/app/views/layouts/app.twig
+++ b/app/views/layouts/app.twig
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<html lang="{{ config('language') }}">
 
 <meta charset="utf-8">
 <meta name="description" content="{{ config('meta_description') }}">


### PR DESCRIPTION
Right now no lang(uage) is set on the html tag. We should pass the default one from config to inform the browser of the correct language to use.