### PR TITLE
Fixed the env name for NPM

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -36,6 +36,6 @@ services:
     volumes:
       - ./:/var/www/html
     ports:
-      - ${APP_PORT:-5173}:5173
+      - ${NPM_PORT:-5173}:5173
     user: ${HOST_USER_ID:-0}:${HOST_GROUP_ID:-0}
     command: npm run dev


### PR DESCRIPTION
The env name assigned to the port to the NPM component was the same as the one for the main application, this has been fixed.