### PR TITLE
Make .m4a files show a "music" icon

### DIFF
--- a/app/config/icons.php
+++ b/app/config/icons.php
@@ -68,6 +68,7 @@ return [
         'mov' => 'fas fa-video',
         'mp3' => 'fas fa-music',
         'mp4' => 'fas fa-video',
+        'm4a' => 'fas fa-music',
         'mpa' => 'fas fa-music',
         'mpg' => 'fas fa-video',
         'msg' => 'fas fa-envelope',


### PR DESCRIPTION
Small change, my instance has a lot of mixed audio files and .m4as always stand out as they just use the generic 'file' icon